### PR TITLE
Adds delegate methods that enable a workflow to enter & confirm a new PIN

### DIFF
--- a/THPinViewController/THPinView.h
+++ b/THPinViewController/THPinView.h
@@ -32,4 +32,6 @@
 
 - (instancetype)initWithDelegate:(id<THPinViewDelegate>)delegate NS_DESIGNATED_INITIALIZER;
 
+- (void)resetInput;
+
 @end

--- a/THPinViewController/THPinView.m
+++ b/THPinViewController/THPinView.m
@@ -244,6 +244,8 @@
         return;
     }
     
+    self.userInteractionEnabled = NO;
+    
     if ([self.delegate pinView:self isPinValid:self.input])
     {
         double delayInSeconds = 0.3f;
@@ -268,6 +270,7 @@
     self.input = [NSMutableString string];
     [self.inputCirclesView unfillAllCircles];
     [self updateBottomButton];
+    self.userInteractionEnabled = YES;
 }
 
 @end

--- a/THPinViewController/THPinViewController.h
+++ b/THPinViewController/THPinViewController.h
@@ -23,12 +23,30 @@ static const NSInteger THPinViewControllerContentViewTag = 14742;
 
 @optional
 - (void)incorrectPinEnteredInPinViewController:(THPinViewController *)pinViewController;
+
 - (void)pinViewControllerWillDismissAfterPinEntryWasSuccessful:(THPinViewController *)pinViewController;
+
+/**
+ The pinViewController is automatically dismissed unless the delegate implements this method returning \c NO.
+ One reason to prevent dismissing would be to use this view controller to let the user set up the PIN by entering the number, then confirming it.
+   1. After the user has entered the first number, return \c NO to keep the controller visible,
+   2. change the prompt in /c -pinViewControllerWillReset:,
+   3. finally return \c YES after the user has successfully entered the new PIN a second time.
+ */
+- (BOOL)pinViewControllerShouldDismissAfterPinEntryWasSuccessful:(THPinViewController *)pinViewController;
 - (void)pinViewControllerDidDismissAfterPinEntryWasSuccessful:(THPinViewController *)pinViewController;
+
 - (void)pinViewControllerWillDismissAfterPinEntryWasUnsuccessful:(THPinViewController *)pinViewController;
 - (void)pinViewControllerDidDismissAfterPinEntryWasUnsuccessful:(THPinViewController *)pinViewController;
+
 - (void)pinViewControllerWillDismissAfterPinEntryWasCancelled:(THPinViewController *)pinViewController;
 - (void)pinViewControllerDidDismissAfterPinEntryWasCancelled:(THPinViewController *)pinViewController;
+
+/**
+ Called when the delegate returned \c NO for \c pinViewControllerShouldDismissAfterPinEntryWasSuccessful:
+ This gives the delegate a chance to update the promptTitle and/or any colors while the pin view is refreshed.
+ */
+- (void)pinViewControllerWillReset:(THPinViewController *)pinViewController;
 
 @end
 

--- a/THPinViewController/THPinViewController.m
+++ b/THPinViewController/THPinViewController.m
@@ -209,14 +209,33 @@
 
 - (void)correctPinWasEnteredInPinView:(THPinView *)pinView
 {
-    if ([self.delegate respondsToSelector:@selector(pinViewControllerWillDismissAfterPinEntryWasSuccessful:)]) {
-        [self.delegate pinViewControllerWillDismissAfterPinEntryWasSuccessful:self];
+    BOOL shouldDismiss = YES;
+    if ([self.delegate respondsToSelector:@selector(pinViewControllerShouldDismissAfterPinEntryWasSuccessful:)]) {
+        shouldDismiss = [self.delegate pinViewControllerShouldDismissAfterPinEntryWasSuccessful:self];
     }
-    [self dismissViewControllerAnimated:YES completion:^{
-        if ([self.delegate respondsToSelector:@selector(pinViewControllerDidDismissAfterPinEntryWasSuccessful:)]) {
-            [self.delegate pinViewControllerDidDismissAfterPinEntryWasSuccessful:self];
+    
+    if (shouldDismiss) {
+        if ([self.delegate respondsToSelector:@selector(pinViewControllerWillDismissAfterPinEntryWasSuccessful:)]) {
+            [self.delegate pinViewControllerWillDismissAfterPinEntryWasSuccessful:self];
         }
-    }];
+        [self dismissViewControllerAnimated:YES completion:^{
+            if ([self.delegate respondsToSelector:@selector(pinViewControllerDidDismissAfterPinEntryWasSuccessful:)]) {
+                [self.delegate pinViewControllerDidDismissAfterPinEntryWasSuccessful:self];
+            }
+        }];
+    } else {
+        [UIView animateWithDuration:0.25 animations:^{
+            self.pinView.alpha = 0.2;
+        } completion:^(BOOL finished) {
+            if ([self.delegate respondsToSelector:@selector(pinViewControllerWillReset:)]) {
+                [self.delegate pinViewControllerWillReset:self];
+            }
+            [self.pinView resetInput];
+            [UIView animateWithDuration:0.15 animations:^{
+                self.pinView.alpha = 1.0;
+            }];
+        }];
+    }
 }
 
 - (void)incorrectPinWasEnteredInPinView:(THPinView *)pinView


### PR DESCRIPTION
Hi Thomas,
I added two delegate methods that allowed me to keep the pin view controller open. I wanted that for the workflow of entering a new PIN and then have the user confirm it without having the pin view controller disappearing between the two steps.

I am not sure if this fits with the direction you would like take your controller, but here it is in case you find it useful.

Thanks,
nils
