### PR TITLE
Add support for multi-line prompt label

### DIFF
--- a/THPinViewController/THPinView.m
+++ b/THPinViewController/THPinView.m
@@ -39,6 +39,7 @@
         _promptLabel = [[UILabel alloc] init];
         _promptLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _promptLabel.textAlignment = NSTextAlignmentCenter;
+        _promptLabel.numberOfLines = 0;
         _promptLabel.font = [UIFont systemFontOfSize:(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) ? 22.0f : 18.0f];
         [_promptLabel setContentCompressionResistancePriority:UILayoutPriorityFittingSizeLevel
                                                       forAxis:UILayoutConstraintAxisHorizontal];


### PR DESCRIPTION
When using a long string as prompt, it gets quickly truncated. With this PR, it automatically adjusts to the needed number of lines.
