### PR TITLE
Adds property for square buttons.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# Xcode
+build/*
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+!default.xcworkspace
+project.xcworkspace
+xcuserdata
+profile
+*.moved-aside
+DerivedData
+.idea/
+.DS_Store
+
+# xcode noise
+build/*
+*.pbxuser
+*.mode1v3
+*.swp
+*~.nib
+*.perspective
+*.perspectivev3
+*.xcbkptlist
+*.xcuserstate
+
+# old skool
+.svn
+
+# osx noise
+.DS_Store
+profile
+
+# Localization Manager
+*.locuser
+
+.ruby-gemset
+.ruby-version

--- a/THPinViewController/THPinNumButton.h
+++ b/THPinViewController/THPinNumButton.h
@@ -14,7 +14,7 @@
 @property (nonatomic, readonly, assign) NSUInteger number;
 @property (nonatomic, readonly, copy) NSString *letters;
 
-- (instancetype)initWithNumber:(NSUInteger)number letters:(NSString *)letters NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithNumber:(NSUInteger)number letters:(NSString *)letters squareButtons:(BOOL)squareButtons NS_DESIGNATED_INITIALIZER;
 
 + (CGFloat)diameter;
 

--- a/THPinViewController/THPinNumButton.m
+++ b/THPinViewController/THPinNumButton.m
@@ -23,7 +23,7 @@
 
 @implementation THPinNumButton
 
-- (instancetype)initWithNumber:(NSUInteger)number letters:(NSString *)letters
+- (instancetype)initWithNumber:(NSUInteger)number letters:(NSString *)letters squareButtons:(BOOL)squareButtons
 {
     self = [super init];
     if (self)
@@ -31,7 +31,9 @@
         _number = number;
         _letters = letters;
         
-        self.layer.cornerRadius = [[self class] diameter] / 2.0f;
+        if (!squareButtons) {
+            self.layer.cornerRadius = [[self class] diameter] / 2.0f;
+        }
         self.layer.borderWidth = 1.0f;
         
         UIView *contentView = [[UIView alloc] init];

--- a/THPinViewController/THPinNumPadView.h
+++ b/THPinViewController/THPinNumPadView.h
@@ -21,6 +21,7 @@
 
 @property (nonatomic, weak) id<THPinNumPadViewDelegate> delegate;
 @property (nonatomic, assign) BOOL hideLetters;
+@property (nonatomic, assign) BOOL squareButtons;
 
 - (instancetype)initWithDelegate:(id<THPinNumPadViewDelegate>)delegate;
 

--- a/THPinViewController/THPinNumPadView.m
+++ b/THPinViewController/THPinNumPadView.m
@@ -23,6 +23,7 @@
     self = [self init];
     if (self)
     {
+        _squareButtons = NO;
         _delegate = delegate;
     }
     return self;
@@ -78,7 +79,8 @@
             
             NSUInteger number = (row < 3) ? row * 3 + col + 1 : 0;
             THPinNumButton *button = [[THPinNumButton alloc] initWithNumber:number
-                                                                    letters:[self lettersForRow:row column:col]];
+                                                                    letters:[self lettersForRow:row column:col]
+                                                              squareButtons:self.squareButtons];
             button.translatesAutoresizingMaskIntoConstraints = NO;
             button.backgroundColor = self.backgroundColor;
             [button addTarget:self action:@selector(numberButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
@@ -180,6 +182,16 @@
         return;
     }
     _hideLetters = hideLetters;
+    [self setupViews];
+}
+
+- (void)setSquareButtons:(BOOL)squareButtons
+{
+    if (self.squareButtons == squareButtons) {
+        return;
+    }
+    
+    _squareButtons = squareButtons;
     [self setupViews];
 }
 

--- a/THPinViewController/THPinView.h
+++ b/THPinViewController/THPinView.h
@@ -30,6 +30,6 @@
 @property (nonatomic, assign) BOOL hideLetters;
 @property (nonatomic, assign) BOOL disableCancel;
 
-- (instancetype)initWithDelegate:(id<THPinViewDelegate>)delegate NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDelegate:(id<THPinViewDelegate>)delegate squareButtons:(BOOL)squareButtons NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/THPinViewController/THPinView.m
+++ b/THPinViewController/THPinView.m
@@ -28,7 +28,7 @@
 
 @implementation THPinView
 
-- (instancetype)initWithDelegate:(id<THPinViewDelegate>)delegate
+- (instancetype)initWithDelegate:(id<THPinViewDelegate>)delegate squareButtons:(BOOL)squareButtons
 {
     self = [super init];
     if (self)
@@ -55,6 +55,7 @@
                                                         multiplier:1.0f constant:0.0f]];
         
         _numPadView = [[THPinNumPadView alloc] initWithDelegate:self];
+        _numPadView.squareButtons = squareButtons;
         _numPadView.translatesAutoresizingMaskIntoConstraints = NO;
         _numPadView.backgroundColor = self.backgroundColor;
         [self addSubview:_numPadView];
@@ -104,12 +105,15 @@
             [vFormat appendString:@"-(paddingBetweenNumPadAndBottomButton)-[bottomButton]"];
             BOOL isFourInchScreen = (fabs(CGRectGetHeight([[UIScreen mainScreen] bounds]) - 568.0f) < DBL_EPSILON);
             if (isFourInchScreen) {
-                _paddingBetweenPromptLabelAndInputCircles = 22.5f;
                 _paddingBetweenInputCirclesAndNumPad = 41.5f;
+                _paddingBetweenPromptLabelAndInputCircles = 22.5f;
                 _paddingBetweenNumPadAndBottomButton = 19.0f;
             } else {
-                _paddingBetweenPromptLabelAndInputCircles = 15.5f;
                 _paddingBetweenInputCirclesAndNumPad = 14.0f;
+                if (squareButtons) {
+                    _paddingBetweenInputCirclesAndNumPad = 14.0f + 10.5f;
+                }
+                _paddingBetweenPromptLabelAndInputCircles = 15.5f;
                 _paddingBetweenNumPadAndBottomButton = -7.5f;
             }
         }

--- a/THPinViewController/THPinViewController.h
+++ b/THPinViewController/THPinViewController.h
@@ -41,6 +41,7 @@ static const NSInteger THPinViewControllerContentViewTag = 14742;
 @property (nonatomic, strong) UIColor *promptColor;
 @property (nonatomic, assign) BOOL hideLetters; // hides the letters on the number buttons
 @property (nonatomic, assign) BOOL disableCancel; // hides the cancel button
+@property (nonatomic, assign) BOOL squareButtons; // makes the number buttons square if YES
 
 - (instancetype)initWithDelegate:(id<THPinViewControllerDelegate>)delegate squareButtons:(BOOL)squareButtons NS_DESIGNATED_INITIALIZER;
 

--- a/THPinViewController/THPinViewController.h
+++ b/THPinViewController/THPinViewController.h
@@ -42,6 +42,6 @@ static const NSInteger THPinViewControllerContentViewTag = 14742;
 @property (nonatomic, assign) BOOL hideLetters; // hides the letters on the number buttons
 @property (nonatomic, assign) BOOL disableCancel; // hides the cancel button
 
-- (instancetype)initWithDelegate:(id<THPinViewControllerDelegate>)delegate NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDelegate:(id<THPinViewControllerDelegate>)delegate squareButtons:(BOOL)squareButtons NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/THPinViewController/THPinViewController.m
+++ b/THPinViewController/THPinViewController.m
@@ -15,7 +15,6 @@
 @property (nonatomic, strong) THPinView *pinView;
 @property (nonatomic, strong) UIView *blurView;
 @property (nonatomic, strong) NSArray *blurViewContraints;
-@property (nonatomic, assign) BOOL squareButtons; // makes the number buttons square if YES
 
 @end
 
@@ -143,6 +142,15 @@
     _disableCancel = disableCancel;
     self.pinView.disableCancel = self.disableCancel;
 }
+
+- (void)setSquareButtons:(BOOL)squareButtons
+{
+    if (self.squareButtons == squareButtons) {
+        return;
+    }
+    _squareButtons = squareButtons;
+}
+
 
 #pragma mark - Blur
 

--- a/THPinViewController/THPinViewController.m
+++ b/THPinViewController/THPinViewController.m
@@ -15,18 +15,20 @@
 @property (nonatomic, strong) THPinView *pinView;
 @property (nonatomic, strong) UIView *blurView;
 @property (nonatomic, strong) NSArray *blurViewContraints;
+@property (nonatomic, assign) BOOL squareButtons; // makes the number buttons square if YES
 
 @end
 
 @implementation THPinViewController
 
-- (instancetype)initWithDelegate:(id<THPinViewControllerDelegate>)delegate
+- (instancetype)initWithDelegate:(id<THPinViewControllerDelegate>)delegate squareButtons:(BOOL)squareButtons
 {
     self = [super init];
     if (self) {
         _delegate = delegate;
         _backgroundColor = [UIColor whiteColor];
         _translucentBackground = NO;
+        _squareButtons = squareButtons;
         NSBundle *bundle = [NSBundle bundleWithPath:[[NSBundle mainBundle] pathForResource:@"THPinViewController"
                                                                                     ofType:@"bundle"]];
         _promptTitle = NSLocalizedStringFromTableInBundle(@"prompt_title", @"THPinViewController", bundle, nil);
@@ -45,7 +47,7 @@
         self.view.backgroundColor = self.backgroundColor;
     }
     
-    self.pinView = [[THPinView alloc] initWithDelegate:self];
+    self.pinView = [[THPinView alloc] initWithDelegate:self squareButtons:_squareButtons];
     self.pinView.backgroundColor = self.view.backgroundColor;
     self.pinView.promptTitle = self.promptTitle;
     self.pinView.promptColor = self.promptColor;

--- a/THPinViewControllerExample/THViewController.m
+++ b/THPinViewControllerExample/THViewController.m
@@ -96,7 +96,7 @@ static const NSUInteger THNumberOfPinEntries = 6;
 
 - (void)showPinViewAnimated:(BOOL)animated
 {
-    THPinViewController *pinViewController = [[THPinViewController alloc] initWithDelegate:self];
+    THPinViewController *pinViewController = [[THPinViewController alloc] initWithDelegate:self squareButtons:NO];
     pinViewController.promptTitle = @"Enter PIN";
     UIColor *darkBlueColor = [UIColor colorWithRed:0.012f green:0.071f blue:0.365f alpha:1.0f];
     pinViewController.promptColor = darkBlueColor;


### PR DESCRIPTION
This is needed for when the parent view controller is added as a storyboard item.

The problem is that there is no access to the initializer to set the square buttons (which is what the previous PR did) when the view controller is loaded through the storyboard.
The solution is to make it a public accessible property.  Proper usage of this property is the same as other properties and must be set before the parent viewDidLoad gets called.

Please be aware that this is a publicly available repository.

cc @hidrees @Katee 