### PR TITLE
Feature/fix bundle path

### DIFF
--- a/THPinViewController/THPinView.m
+++ b/THPinViewController/THPinView.m
@@ -200,7 +200,7 @@
 
 - (void)updateBottomButton
 {
-    NSBundle *bundle = [NSBundle bundleWithPath:[[NSBundle mainBundle] pathForResource:@"THPinViewController"
+    NSBundle *bundle = [NSBundle bundleWithPath:[[NSBundle bundleForClass:[self class]] pathForResource:@"THPinViewController"
                                                                                 ofType:@"bundle"]];
     if (self.input.length == 0) {
         self.bottomButton.hidden = self.disableCancel;

--- a/THPinViewController/THPinViewController.m
+++ b/THPinViewController/THPinViewController.m
@@ -27,7 +27,7 @@
         _delegate = delegate;
         _backgroundColor = [UIColor whiteColor];
         _translucentBackground = NO;
-        NSBundle *bundle = [NSBundle bundleWithPath:[[NSBundle mainBundle] pathForResource:@"THPinViewController"
+        NSBundle *bundle = [NSBundle bundleWithPath:[[NSBundle bundleForClass:[self class]] pathForResource:@"THPinViewController"
                                                                                     ofType:@"bundle"]];
         _promptTitle = NSLocalizedStringFromTableInBundle(@"prompt_title", @"THPinViewController", bundle, nil);
     }


### PR DESCRIPTION
Hi there,

I fixed a issue that the resource bundle path is error if I integrate THPinViewController by cocoa pods. Due to resource bundle is embedded in THPinViewControlller.framework but no main bundle, `[[NSbundle mainBundle] pathForResource:]` will leads to nil path and resource bundle cannot be located.