### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,14 +78,14 @@ See the example project for more details.
 Installation
 -------
 
-###As a Git Submodule
+### As a Git Submodule
 
 ```
 git submodule add git://github.com/antiraum/THPinViewController.git <local path>
 git submodule update
 ```
 
-###Via CocoaPods
+### Via CocoaPods
 
 Add this line to your Podfile:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
